### PR TITLE
Remove spaces after lim and log

### DIFF
--- a/iosMath.podspec
+++ b/iosMath.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "iosMath"
-  s.version      = "1.1.2"
+  s.version      = "1.1.3"
   s.summary      = "Math equation rendering for iOS and OS X"
   s.description  = <<-DESC
 iosMath is a library for typesetting math formulas in iOS and OS X using

--- a/iosMath/lib/MTMathList.h
+++ b/iosMath/lib/MTMathList.h
@@ -243,6 +243,8 @@ typedef NS_ENUM(NSUInteger, MTFontStyle)
  */
 @property (nonatomic) BOOL limits;
 
+@property (nonatomic) BOOL isTrigFunction;
+
 @end
 
 /** An inner atom. This denotes an atom which contains a math list inside it. An inner atom

--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -459,6 +459,18 @@ static NSString* typeToText(MTMathAtomType type) {
     return op;
 }
 
+// Return YES if string is a trig function, otherwise return NO
+- (BOOL)isTrigFunction {
+  NSString* string = self.stringValue;
+  NSArray *trigFunctions = @[@"sin", @"cos", @"tan", @"sec", @"csc", @"cot", @"arcsin", @"arccos", @"arctan", @"arccsc", @"arcsec", @"arccot", @"sinh", @"cosh", @"tanh", @"csch", @"sech", @"coth"];
+  for (NSString *trigFunction in trigFunctions) {
+    if ([string isEqualToString:trigFunction]) {
+      return YES;
+    }
+  }
+  return NO;
+}
+
 @end
 
 #pragma mark - MTInner

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -839,7 +839,9 @@ NSString *const MTParseError = @"ParseError";
             MTLargeOperator* op = (MTLargeOperator*) atom;
             NSString* command = [MTMathAtomFactory latexSymbolNameForAtom:atom];
             MTLargeOperator* originalOp = (MTLargeOperator*) [MTMathAtomFactory atomForLatexSymbolName:command];
-            if ([command isEqualToString:@"log"]) {
+            BOOL flag = [command isEqualToString:@"lim"];
+            NSLog(flag ? @"Yes" : @"No");
+            if ([command isEqualToString:@"log"] || [command isEqualToString:@"lim"]) {
                 [str appendFormat:@"\\%@", command];
             } else {
                 [str appendFormat:@"\\%@ ", command];

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -839,7 +839,7 @@ NSString *const MTParseError = @"ParseError";
             MTLargeOperator* op = (MTLargeOperator*) atom;
             NSString* command = [MTMathAtomFactory latexSymbolNameForAtom:atom];
             MTLargeOperator* originalOp = (MTLargeOperator*) [MTMathAtomFactory atomForLatexSymbolName:command];
-            if ([command isEqualToString:@"log"]) {
+            if ([command isEqualToString:@"log"] || op.isTrigFunction) {
                 [str appendFormat:@"\\%@", command];
             } else {
                 [str appendFormat:@"\\%@ ", command];
@@ -890,7 +890,7 @@ NSString *const MTParseError = @"ParseError";
         if (atom.superScript) {
             [str appendFormat:@"^{%@}", [self mathListToString:atom.superScript]];
         }
-        
+
         if (atom.subScript) {
             [str appendFormat:@"_{%@}", [self mathListToString:atom.subScript]];
         }

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -839,8 +839,6 @@ NSString *const MTParseError = @"ParseError";
             MTLargeOperator* op = (MTLargeOperator*) atom;
             NSString* command = [MTMathAtomFactory latexSymbolNameForAtom:atom];
             MTLargeOperator* originalOp = (MTLargeOperator*) [MTMathAtomFactory atomForLatexSymbolName:command];
-            BOOL flag = [command isEqualToString:@"lim"];
-            NSLog(flag ? @"Yes" : @"No");
             if ([command isEqualToString:@"log"] || [command isEqualToString:@"lim"]) {
                 [str appendFormat:@"\\%@", command];
             } else {


### PR DESCRIPTION
- Removes space after lim: `lim_{4}` instead of `lim _{4}` Fixes https://github.com/doberman/pearson-math-ios/issues/26
- Removes space after log: `log_{2}10` instead of `log _{2}10`
- Version Bump to 1.1.3

~TODO in a separate PR remove space for all trig functions: `cos(10)` instead of `cos (10)`~

- Merged another branch with the changes to remove the extra space for all trig functions Fixes https://github.com/doberman/pearson-math-ios/issues/21