### PR TITLE
Changed imports to lowercase iosMath to reflect actual folder name

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ repository as a git submodule to your git-tracked project.
 add `libIosMath.a`. You might also need to add `iosMath` to
 the Target Dependencies list.
 4. Add the `MathFontBundle` to the list of `Copy Bundle Resources`.
-5. Include IosMath wherever you need it with `#import <IosMath/IosMath.h>`.
+5. Include IosMath wherever you need it with `#import <iosMath/IosMath.h>`.
 
 ## Usage
 

--- a/iosMath/IosMath.h
+++ b/iosMath/IosMath.h
@@ -8,7 +8,7 @@
 //  This software may be modified and distributed under the terms of the
 //  MIT license. See the LICENSE file for details.
 
-#import <IosMath/MTMathUILabel.h>
-#import <IosMath/MTMathListDisplay.h>
-#import <IosMath/MTMathList.h>
-#import <IosMath/MTMathListBuilder.h>
+#import <iosMath/MTMathUILabel.h>
+#import <iosMath/MTMathListDisplay.h>
+#import <iosMath/MTMathList.h>
+#import <iosMath/MTMathListBuilder.h>


### PR DESCRIPTION
Had issues re-compiling/hot-reloading with injectionIII because of this. Would cause similar issues if running on a case-sensitive system (HFS+ or APFS with case-sensitive enable for example).